### PR TITLE
chore: add rules in xo.config.ts

### DIFF
--- a/apps/vite-frontend/xo.config.ts
+++ b/apps/vite-frontend/xo.config.ts
@@ -42,6 +42,11 @@ const xoConfig: FlatXoConfig = [
       '@typescript-eslint/naming-convention': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
 
+      // Allow `null` in React DOM refs and other nullable TypeScript patterns.
+      // XO's default restricted-types config auto-fixes `null` to `undefined`,
+      // which breaks common React ref typing such as `useRef<T | null>(null)`.
+      '@typescript-eslint/no-restricted-types': 'off',
+
       // Code rules
       'max-params': 'error',
 


### PR DESCRIPTION
// Disable this rule because the default XO config rewrites `null` types to `undefined`.
// That auto-fix is not suitable for React DOM refs, which conventionally use `T | null`.
'@typescript-eslint/no-restricted-types': 'off',