### PR TITLE
fix: align formatting workflows for source files

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,7 @@
 {
   "apps/nestjs-backend/**/*.{ts,tsx,js,jsx}": "npm --workspace nestjs-backend run lint:fix",
   "apps/vite-frontend/**/*.{ts,tsx,js,jsx}": "npm --workspace vite-frontend run lint:fix",
+  "packages/db/**/*.{ts,tsx,js,jsx}": "npm --workspace @next-nest-turbo-auth-boilerplate/db run lint:fix",
   "packages/shared/**/*.{ts,tsx,js,jsx}": "npm --workspace @next-nest-turbo-auth-boilerplate/shared run lint:fix",
-  "*.{json,md,css,html,ts,tsx,js,jsx}": ["npm run format"]
+  "*.{json,md,css,html,yml,yaml}": "prettier --write"
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# TypeScript and JavaScript source files are normalized by workspace lint:fix commands.
+# Keeping them out of Prettier avoids save-time churn and conflicts with XO autofix.
+apps/**/*.ts
+apps/**/*.tsx
+apps/**/*.js
+apps/**/*.jsx
+packages/**/*.ts
+packages/**/*.tsx
+packages/**/*.js
+packages/**/*.jsx

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ REDIS_PASSWORD=redis_pass
 | `npm run dev`          | 并行启动前后端开发环境                                       |
 | `npm run dev:all`      | 先起基础设施再启动开发环境                                   |
 | `npm run build`        | 构建整个 monorepo；会先构建 `packages/db`、`packages/shared` |
-| `npm run format`       | 对 `ts/tsx/md` 执行 Prettier                                 |
+| `npm run format`       | 对文档与静态文本资源执行 Prettier                            |
 | `npm run start:dev`    | 按 workspace 的 `start:dev` 运行                             |
 | `npm run start:prod`   | 按 workspace 的 `start:prod` 运行                            |
 
@@ -211,7 +211,7 @@ REDIS_PASSWORD=redis_pass
 | `npm run test:unit`     | 可直接使用             | 当前已接通后端健康检查单测                                                                                            |
 | `npm run test:unit:cov` | 有前提但可用           | 基于同一套测试资产；本轮未单独重跑 coverage                                                                           |
 | `npm run test:e2e`      | 可直接使用             | 当前已接通后端 Jest E2E smoke test 与前端 Playwright smoke test；首次运行前可能需要 `npx playwright install chromium` |
-| `npm run init`          | 适合模板二次定制时使用 | 会重命名 workspace 包名、重写内部依赖，并生成可选的根级 `.env` Docker 覆盖模板                                       |
+| `npm run init`          | 适合模板二次定制时使用 | 会重命名 workspace 包名、重写内部依赖，并生成可选的根级 `.env` Docker 覆盖模板                                        |
 | `npm run copilot:sync`  | 仓库维护脚本           | 只在你明确知道它要同步什么时再用                                                                                      |
 
 ## 运行机制拆解

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -30,7 +30,7 @@
 | 场景                      | 建议命令                               |
 | ------------------------- | -------------------------------------- |
 | 改了通用代码路径          | `npm run build`                        |
-| 改了格式或文档            | `npm run format`                       |
+| 改了文档或静态文本资源    | `npm run format`                       |
 | 改了 Prisma schema / 迁移 | `npm run build -w packages/db`         |
 | 改了 shared DTO / 类型    | `npm run build -w packages/shared`     |
 | 改了前端业务逻辑          | `npm run build -w apps/vite-frontend`  |
@@ -45,6 +45,12 @@
 | `npm run test:e2e`  | 可直接使用       | 当前已接通后端 Jest E2E 与前端 Playwright smoke test |
 
 如果你补的是文档，不需要为了“看起来完整”而声称这些测试已可用；应如实记录现状。
+
+补充说明：
+
+- `npm run format` 只处理 `json/md/css/html/yml/yaml`
+- `apps/*` 和 `packages/*` 下的 `ts/tsx/js/jsx` 统一通过各 workspace 的 `lint:fix` 收敛格式
+- 仓库已新增 `.prettierignore`，避免编辑器在保存代码文件时再次用 Prettier 改写缩进
 
 首次运行 Playwright 测试前，如果本机还没有浏览器二进制，需要执行：
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:unit": "turbo run test:unit",
     "test:e2e": "turbo run test:e2e",
     "test:unit:cov": "turbo run test:unit:cov",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format": "prettier --write \"**/*.{json,md,css,html,yml,yaml}\"",
     "init": "node scripts/init.js",
     "copilot:sync": "node scripts/copilot-sync.js",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- stop running Prettier on workspace source files during root `format` and `lint-staged`
- add `.prettierignore` entries for `apps/*` and `packages/*` source files so editor save actions do not reformat them
- update contributor docs to reflect that code formatting should go through workspace `lint:fix`

## Verification
- `npx prettier --file-info apps/nestjs-backend/src/common/decorators/validate-header/types/header-decorator.param.type.ts`
- `npx prettier --check .lintstagedrc README.md docs/CONTRIB.md package.json`
- `git commit` pre-commit hook (passed)
