### PR TITLE
ci: add test coverage and caching to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # -------- Build --------
   build:
@@ -18,6 +22,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.13.1
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,6 +3,10 @@ name: Quality
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # -------- Lint --------
   lint:
@@ -18,6 +22,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.13.1
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -39,12 +44,41 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.13.1
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run npm audit
         run: npm audit --omit=dev --audit-level=moderate
+
+  # -------- Tests --------
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.13.1
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run e2e tests
+        run: npm run test:e2e
 
   # -------- TruffleHog --------
   trufflehog:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Run Release
@@ -16,6 +20,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: '0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.13.1
+          cache: npm
 
       - name: Get next version
         id: get_next_version


### PR DESCRIPTION
Closes #28

## Summary
- add a `Tests` job to the quality workflow
- install Playwright Chromium before e2e execution in CI
- enable npm cache for setup-node across quality, build, and release workflows
- add workflow concurrency controls so newer runs cancel stale ones

## Validation
- `ruby -e "require 'yaml'; %w[.github/workflows/quality.yml .github/workflows/build.yml .github/workflows/release.yml].each { |f| YAML.load_file(f) }"`
- `npm run lint`
- `npm run test:unit`
- `npm run test:e2e`
