### PR TITLE
refactor: centralize locale constants

### DIFF
--- a/apps/vite-frontend/src/components/footer/components/LocaleSelect/locale-select.component.tsx
+++ b/apps/vite-frontend/src/components/footer/components/LocaleSelect/locale-select.component.tsx
@@ -3,9 +3,8 @@ import {useTranslation} from 'react-i18next';
 import {useParams, useNavigate, useLocation} from 'react-router-dom';
 import {Languages} from 'lucide-react';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select.tsx';
+import {defaultLocale, supportedLocales} from '@/i18n/constants.ts';
 import {replaceLocaleInPath} from '@/i18n/navigation.ts';
-
-const supportedLocales = ['en', 'zh'];
 
 export function LocaleSelect(): JSX.Element {
   const {t} = useTranslation();
@@ -24,7 +23,7 @@ export function LocaleSelect(): JSX.Element {
   };
 
   return (
-    <Select disabled={isPending} value={locale ?? 'en'} onValueChange={onLocaleChange}>
+    <Select disabled={isPending} value={locale ?? defaultLocale} onValueChange={onLocaleChange}>
       <SelectTrigger className="w-[180px]">
         <Languages className="mr-2 h-4 w-4" />
         <SelectValue />

--- a/apps/vite-frontend/src/i18n/LanguageSync.tsx
+++ b/apps/vite-frontend/src/i18n/LanguageSync.tsx
@@ -1,8 +1,8 @@
 import {useEffect} from 'react';
 import {useParams, useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
-
-const SUPPORTED_LOCALES = new Set(['en', 'zh']);
+import {defaultLocale, isSupportedLocale} from '@/i18n/constants.ts';
+import {getLocalePath} from '@/i18n/navigation.ts';
 
 export function LanguageSync() {
   const {locale} = useParams<{locale: string}>();
@@ -10,8 +10,8 @@ export function LanguageSync() {
   const {i18n} = useTranslation();
 
   useEffect(() => {
-    if (!locale || !SUPPORTED_LOCALES.has(locale)) {
-      navigate('/en', {replace: true});
+    if (!isSupportedLocale(locale)) {
+      navigate(getLocalePath(defaultLocale), {replace: true});
       return;
     }
 

--- a/apps/vite-frontend/src/i18n/config.ts
+++ b/apps/vite-frontend/src/i18n/config.ts
@@ -1,13 +1,14 @@
 import i18next from 'i18next';
 import {initReactI18next} from 'react-i18next';
 import HttpBackend from 'i18next-http-backend';
+import {defaultLocale, supportedLocales} from '@/i18n/constants.ts';
 
 i18next
   .use(HttpBackend)
   .use(initReactI18next)
   .init({
-    fallbackLng: 'en',
-    supportedLngs: ['en', 'zh'],
+    fallbackLng: defaultLocale,
+    supportedLngs: [...supportedLocales],
     defaultNS: 'translation',
     debug: false,
     interpolation: {

--- a/apps/vite-frontend/src/i18n/constants.ts
+++ b/apps/vite-frontend/src/i18n/constants.ts
@@ -1,0 +1,11 @@
+export const defaultLocale = 'en';
+
+export const supportedLocales = ['en', 'zh'] as const;
+
+export type SupportedLocale = (typeof supportedLocales)[number];
+
+const supportedLocaleSet = new Set<string>(supportedLocales);
+
+export function isSupportedLocale(locale: string | undefined): locale is SupportedLocale {
+  return typeof locale === 'string' && supportedLocaleSet.has(locale);
+}

--- a/apps/vite-frontend/src/i18n/navigation.ts
+++ b/apps/vite-frontend/src/i18n/navigation.ts
@@ -1,7 +1,7 @@
-export {Link, useNavigate, useLocation, Navigate} from 'react-router-dom';
+import {defaultLocale, isSupportedLocale} from '@/i18n/constants.ts';
 
-const defaultLocale = 'en';
-const supportedLocales = new Set(['en', 'zh']);
+export {defaultLocale, supportedLocales} from '@/i18n/constants.ts';
+export {Link, useNavigate, useLocation, Navigate} from 'react-router-dom';
 
 function normalizePath(path: string): string {
   if (!path || path === '/') {
@@ -12,7 +12,7 @@ function normalizePath(path: string): string {
 }
 
 export function getLocale(locale: string | undefined): string {
-  if (!locale || !supportedLocales.has(locale)) {
+  if (!isSupportedLocale(locale)) {
     return defaultLocale;
   }
 
@@ -34,12 +34,10 @@ export function replaceLocaleInPath(pathname: string, locale: string | undefined
   const normalizedLocale = getLocale(locale);
   const segments = pathname.split('/');
 
-  if (segments.length > 1 && supportedLocales.has(segments[1]!)) {
+  if (segments.length > 1 && isSupportedLocale(segments[1])) {
     segments[1] = normalizedLocale;
     return segments.join('/');
   }
 
   return getLocalePath(normalizedLocale, pathname);
 }
-
-export {defaultLocale, supportedLocales};

--- a/apps/vite-frontend/src/pages/NotFound.tsx
+++ b/apps/vite-frontend/src/pages/NotFound.tsx
@@ -1,11 +1,13 @@
 import {Link} from 'react-router-dom';
+import {defaultLocale} from '@/i18n/constants.ts';
+import {getLocalePath} from '@/i18n/navigation.ts';
 
 export function NotFound() {
   return (
     <div>
       <h2>404 - Page Not Found</h2>
       <p>The page you are looking for does not exist.</p>
-      <Link to="/en">Go to Home</Link>
+      <Link to={getLocalePath(defaultLocale)}>Go to Home</Link>
     </div>
   );
 }

--- a/apps/vite-frontend/src/router/index.tsx
+++ b/apps/vite-frontend/src/router/index.tsx
@@ -5,6 +5,8 @@ import {BareLayout} from '@/layouts/BareLayout.tsx';
 import {ProvidersLayout} from '@/layouts/ProvidersLayout.tsx';
 import {PrivateRoute} from '@/router/PrivateRoute.tsx';
 import {LoadingAnimation} from '@/components/loading-animation/loading-animation.component';
+import {defaultLocale} from '@/i18n/constants.ts';
+import {getLocalePath} from '@/i18n/navigation.ts';
 
 const Home = React.lazy(async () => {
   const mod = await import('../pages/Home.tsx');
@@ -46,7 +48,7 @@ function infoPageElement(pageKey: 'about' | 'contact' | 'imprint' | 'privacy' | 
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <Navigate replace to="/en" />,
+    element: <Navigate replace to={getLocalePath(defaultLocale)} />,
   },
   {
     path: '/:locale',


### PR DESCRIPTION
Closes #29

## Summary
- add a dedicated i18n constants module for locale defaults and validation
- update i18n config, navigation helpers, language sync, footer locale switcher, router redirect, and 404 navigation to use the shared constants
- remove hard-coded locale literals from the targeted frontend entry points

## Validation
- `npm run lint -w apps/vite-frontend`
- `npm run build -w apps/vite-frontend`
- `npm run test:e2e -w apps/vite-frontend`
