### PR TITLE
refactor: consolidate auth session bootstrap

### DIFF
--- a/apps/vite-frontend/src/api/user.api.ts
+++ b/apps/vite-frontend/src/api/user.api.ts
@@ -1,7 +1,13 @@
+import {type AxiosRequestConfig} from 'axios';
 import {type UserDto} from '@next-nest-turbo-auth-boilerplate/shared';
 import {axiosInstance} from '@/lib/axios';
 
+type RequestConfigWithAuthRedirect = AxiosRequestConfig & {
+  skipAuthRedirect?: boolean;
+};
+
 export async function getMeApi(): Promise<UserDto> {
-  const {data} = await axiosInstance.get<UserDto>('/users/me');
+  const requestConfig: RequestConfigWithAuthRedirect = {skipAuthRedirect: true};
+  const {data} = await axiosInstance.get<UserDto>('/users/me', requestConfig);
   return data;
 }

--- a/apps/vite-frontend/src/hooks/use-auth/use-auth.hook.ts
+++ b/apps/vite-frontend/src/hooks/use-auth/use-auth.hook.ts
@@ -5,16 +5,17 @@ import {getMeApi} from '@/api/user.api';
 import {loginApi, logoutApi, registerApi} from '@/api/auth.api';
 import {useAuthStore} from '@/store/auth/auth.store';
 
-const ME_QUERY_KEY = ['users', 'me'] as const;
+export const ME_QUERY_KEY = ['users', 'me'] as const;
 
-export function useMe(): {user: UserDto | undefined; isLoading: boolean; isError: boolean} {
+export function useAuthSessionBootstrap(): void {
   const {setUser, clearAuth} = useAuthStore();
 
-  const {data, isLoading, isError} = useQuery({
+  const {data, isError} = useQuery({
     queryKey: ME_QUERY_KEY,
     queryFn: getMeApi,
     retry: false,
     staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 
   useEffect(() => {
@@ -24,15 +25,17 @@ export function useMe(): {user: UserDto | undefined; isLoading: boolean; isError
       clearAuth();
     }
   }, [data, isError, setUser, clearAuth]);
+}
 
-  return {user: data, isLoading, isError};
+export function useAuthSession(): {user: UserDto | undefined; isAuthenticated: boolean; sessionStatus: string} {
+  const {user, isAuthenticated, sessionStatus} = useAuthStore();
+  return {user, isAuthenticated, sessionStatus};
 }
 
 export function useLogin(): {
   login: (email: string, password: string) => Promise<void>;
   isPending: boolean;
 } {
-  const {setUser} = useAuthStore();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
@@ -40,8 +43,7 @@ export function useLogin(): {
       return loginApi({email, password});
     },
     async onSuccess(result) {
-      setUser(result.user);
-      await queryClient.invalidateQueries({queryKey: ME_QUERY_KEY});
+      queryClient.setQueryData(ME_QUERY_KEY, result.user);
     },
   });
 
@@ -57,7 +59,6 @@ export function useRegister(): {
   register: (email: string, password: string) => Promise<void>;
   isPending: boolean;
 } {
-  const {setUser} = useAuthStore();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
@@ -65,8 +66,7 @@ export function useRegister(): {
       return registerApi({email, password});
     },
     async onSuccess(result) {
-      setUser(result.user);
-      await queryClient.invalidateQueries({queryKey: ME_QUERY_KEY});
+      queryClient.setQueryData(ME_QUERY_KEY, result.user);
     },
   });
 

--- a/apps/vite-frontend/src/layouts/ProvidersLayout.tsx
+++ b/apps/vite-frontend/src/layouts/ProvidersLayout.tsx
@@ -7,6 +7,7 @@ import {ReactQueryProvider} from '@/providers/react-query/react-query.provider';
 import {ToastProvider} from '@/providers/toast/toast.provider';
 import {ConfirmProvider} from '@/providers/confirm/confirm.provider';
 import {ZodErrorProvider} from '@/providers/zod-error/zod-error.provider';
+import {AuthSessionProvider} from '@/providers/auth-session/auth-session.provider';
 import {LoadingAnimation} from '@/components/loading-animation/loading-animation.component';
 
 export function ProvidersLayout() {
@@ -18,6 +19,7 @@ export function ProvidersLayout() {
           <ToastProvider>
             <ConfirmProvider>
               <ReactQueryProvider>
+                <AuthSessionProvider />
                 <LoadingAnimation />
                 <Outlet />
               </ReactQueryProvider>

--- a/apps/vite-frontend/src/lib/axios.ts
+++ b/apps/vite-frontend/src/lib/axios.ts
@@ -1,7 +1,12 @@
 import axios, {type AxiosError, type AxiosResponse, type InternalAxiosRequestConfig} from 'axios';
 import {toast} from 'sonner';
+import {getLocale, getLocalePath} from '@/i18n/navigation.ts';
 import {useAuthStore} from '@/store/auth/auth.store';
 import {useLoadingStore} from '@/store/loading/loading.store';
+
+type RequestConfigWithAuthRedirect = {
+  skipAuthRedirect?: boolean;
+};
 
 type ApiErrorBody = {
   message?: string;
@@ -34,6 +39,10 @@ function getApiBaseUrl(): string {
   return `${normalizeBackendOrigin(backendUrl)}/api/v1`;
 }
 
+function isAuthPagePath(pathname: string): boolean {
+  return /\/(login|register)\/?$/u.test(pathname);
+}
+
 axiosInstance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     useLoadingStore.getState().increment();
@@ -59,9 +68,11 @@ axiosInstance.interceptors.response.use(
     if (status === 401) {
       useAuthStore.getState().clearAuth();
       const pathname = globalThis.window?.location.pathname ?? '';
-      if (!pathname.includes('/login')) {
-        const locale = pathname.split('/')[1] ?? 'en';
-        globalThis.window.location.href = `/${locale}/login`;
+      const localeMatch = /^\/([^/]+)/u.exec(pathname);
+      const locale = getLocale(localeMatch?.[1]);
+      const requestConfig = error.config as RequestConfigWithAuthRedirect | undefined;
+      if (!requestConfig?.skipAuthRedirect && !isAuthPagePath(pathname)) {
+        globalThis.window.location.href = getLocalePath(locale, '/login');
       }
 
       throw error;

--- a/apps/vite-frontend/src/providers/auth-session/auth-session.provider.tsx
+++ b/apps/vite-frontend/src/providers/auth-session/auth-session.provider.tsx
@@ -1,0 +1,7 @@
+import {useAuthSessionBootstrap} from '@/hooks/use-auth/use-auth.hook';
+
+export function AuthSessionProvider(): null {
+  useAuthSessionBootstrap();
+
+  return null;
+}

--- a/apps/vite-frontend/src/router/PrivateRoute.tsx
+++ b/apps/vite-frontend/src/router/PrivateRoute.tsx
@@ -1,7 +1,8 @@
 import {type JSX} from 'react';
 import {Navigate, useParams} from 'react-router-dom';
-import {useMe} from '@/hooks/use-auth/use-auth.hook';
+import {useAuthSession} from '@/hooks/use-auth/use-auth.hook';
 import {LoadingAnimation} from '@/components/loading-animation/loading-animation.component';
+import {getLocalePath} from '@/i18n/navigation.ts';
 
 type PrivateRouteProps = {
   readonly children: JSX.Element;
@@ -9,14 +10,14 @@ type PrivateRouteProps = {
 
 export function PrivateRoute({children}: PrivateRouteProps): JSX.Element {
   const {locale} = useParams<{locale: string}>();
-  const {isLoading, isError} = useMe();
+  const {sessionStatus} = useAuthSession();
 
-  if (isLoading) {
+  if (sessionStatus === 'loading') {
     return <LoadingAnimation />;
   }
 
-  if (isError) {
-    return <Navigate replace to={`/${locale ?? 'en'}/login`} />;
+  if (sessionStatus === 'guest') {
+    return <Navigate replace to={getLocalePath(locale, '/login')} />;
   }
 
   return children;

--- a/apps/vite-frontend/src/store/auth/auth.store.ts
+++ b/apps/vite-frontend/src/store/auth/auth.store.ts
@@ -1,8 +1,11 @@
 import {create} from 'zustand';
 import {type UserDto} from '@next-nest-turbo-auth-boilerplate/shared';
 
+export type AuthSessionStatus = 'loading' | 'authenticated' | 'guest';
+
 type AuthStore = {
   user: UserDto | undefined;
+  sessionStatus: AuthSessionStatus;
   isAuthenticated: boolean;
   setUser: (user: UserDto | undefined) => void;
   clearAuth: () => void;
@@ -10,11 +13,16 @@ type AuthStore = {
 
 export const useAuthStore = create<AuthStore>((set) => ({
   user: undefined,
+  sessionStatus: 'loading',
   isAuthenticated: false,
   setUser(user): void {
-    set({user, isAuthenticated: user !== undefined});
+    set({
+      user,
+      isAuthenticated: user !== undefined,
+      sessionStatus: user === undefined ? 'guest' : 'authenticated',
+    });
   },
   clearAuth(): void {
-    set({user: undefined, isAuthenticated: false});
+    set({user: undefined, sessionStatus: 'guest', isAuthenticated: false});
   },
 }));


### PR DESCRIPTION
Closes #30

## Summary
- move `/users/me` bootstrap into a single app-shell provider backed by React Query
- make `PrivateRoute` consume session state from Zustand instead of firing its own query
- write login/register results into the shared session query cache with `setQueryData`
- keep 401 handling in axios while allowing bootstrap requests to skip forced redirects and using locale helpers for redirect targets

## Validation
- `npm run lint -w apps/vite-frontend`
- `npm run build -w apps/vite-frontend`
- `npm run test:e2e -w apps/vite-frontend`

## Notes
- Playwright still logs a proxy refusal for `/api/v1/users/me` because the current smoke test does not mock auth traffic yet; the test still passes and issue #31 will remove that noise.
