### PR TITLE
test: expand hermetic auth coverage

### DIFF
--- a/apps/nestjs-backend/src/auth/auth.controller.spec.ts
+++ b/apps/nestjs-backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,87 @@
+import {type Response} from 'express';
+import {RegisterDto, LoginDto, UserRole} from '@next-nest-turbo-auth-boilerplate/shared';
+import {AuthService} from './auth.service';
+import {AuthController} from './auth.controller';
+
+const authResponse = {
+  user: {
+    id: 'user-1',
+    email: 'user@example.com',
+    role: UserRole.USER,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  },
+  accessToken: 'signed-token',
+};
+
+describe('AuthController', () => {
+  const authService = {
+    register: jest.fn(async () => authResponse),
+    login: jest.fn(async () => authResponse),
+  } as unknown as AuthService;
+
+  const controller = new AuthController(authService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets the auth cookie when registration succeeds', async () => {
+    const dto: RegisterDto = {
+      email: authResponse.user.email,
+      password: 'password123',
+    };
+    const response = {
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    } as unknown as Response;
+
+    await expect(controller.register(dto, response)).resolves.toEqual(authResponse);
+
+    expect(authService.register).toHaveBeenCalledWith(dto);
+    expect(response.cookie).toHaveBeenCalledWith(
+      'access_token',
+      authResponse.accessToken,
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 604_800_000,
+        sameSite: 'strict',
+      }),
+    );
+  });
+
+  it('sets the auth cookie when login succeeds', async () => {
+    const dto: LoginDto = {
+      email: authResponse.user.email,
+      password: 'password123',
+    };
+    const response = {
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    } as unknown as Response;
+
+    await expect(controller.login(dto, response)).resolves.toEqual(authResponse);
+
+    expect(authService.login).toHaveBeenCalledWith(dto);
+    expect(response.cookie).toHaveBeenCalledWith(
+      'access_token',
+      authResponse.accessToken,
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 604_800_000,
+        sameSite: 'strict',
+      }),
+    );
+  });
+
+  it('clears the auth cookie on logout', () => {
+    const response = {
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    } as unknown as Response;
+
+    controller.logout(response);
+
+    expect(response.clearCookie).toHaveBeenCalledWith('access_token');
+  });
+});

--- a/apps/nestjs-backend/src/auth/auth.service.spec.ts
+++ b/apps/nestjs-backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,102 @@
+import {UnauthorizedException} from '@nestjs/common';
+import {JwtService} from '@nestjs/jwt';
+import {type User} from '@next-nest-turbo-auth-boilerplate/db';
+import {RegisterDto, LoginDto, UserRole} from '@next-nest-turbo-auth-boilerplate/shared';
+import {compare, hash} from 'bcrypt';
+import {UsersService} from '../users/users.service';
+import {AuthService} from './auth.service';
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+const hashMock = jest.mocked(hash);
+const compareMock = jest.mocked(compare);
+
+const user: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  passwordHash: 'stored-password-hash',
+  role: UserRole.USER,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const userDto = {
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt,
+};
+
+describe('AuthService', () => {
+  const usersService = {
+    create: jest.fn(),
+    findByEmail: jest.fn(),
+    toDto: jest.fn(() => userDto),
+  } as unknown as UsersService;
+  const jwtService = {
+    sign: jest.fn(() => 'signed-token'),
+  } as unknown as JwtService;
+
+  const service = new AuthService(usersService, jwtService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hashes the password, creates a user, and signs a token during registration', async () => {
+    const dto: RegisterDto = {
+      email: user.email,
+      password: 'password123',
+    };
+
+    hashMock.mockImplementation(async () => 'hashed-password');
+    jest.mocked(usersService.create).mockResolvedValue(user);
+
+    await expect(service.register(dto)).resolves.toEqual({
+      user: userDto,
+      accessToken: 'signed-token',
+    });
+
+    expect(hashMock).toHaveBeenCalledWith(dto.password, 12);
+    expect(usersService.create).toHaveBeenCalledWith(dto.email, 'hashed-password');
+    expect(jwtService.sign).toHaveBeenCalledWith({sub: user.id, email: user.email, role: user.role});
+    expect(usersService.toDto).toHaveBeenCalledWith(user);
+  });
+
+  it('returns the dto and token for valid login credentials', async () => {
+    const dto: LoginDto = {
+      email: user.email,
+      password: 'password123',
+    };
+
+    jest.mocked(usersService.findByEmail).mockResolvedValue(user);
+    compareMock.mockImplementation(async () => true);
+
+    await expect(service.login(dto)).resolves.toEqual({
+      user: userDto,
+      accessToken: 'signed-token',
+    });
+
+    expect(compareMock).toHaveBeenCalledWith(dto.password, user.passwordHash);
+    expect(jwtService.sign).toHaveBeenCalledWith({sub: user.id, email: user.email, role: user.role});
+    expect(usersService.toDto).toHaveBeenCalledWith(user);
+  });
+
+  it('rejects invalid login credentials', async () => {
+    const dto: LoginDto = {
+      email: user.email,
+      password: 'wrong-password',
+    };
+
+    jest.mocked(usersService.findByEmail).mockResolvedValue(user);
+    compareMock.mockImplementation(async () => false);
+
+    await expect(service.login(dto)).rejects.toThrow(new UnauthorizedException('Invalid credentials'));
+
+    expect(jwtService.sign).not.toHaveBeenCalled();
+  });
+});

--- a/apps/nestjs-backend/src/users/users.controller.spec.ts
+++ b/apps/nestjs-backend/src/users/users.controller.spec.ts
@@ -1,0 +1,47 @@
+import {type User} from '@next-nest-turbo-auth-boilerplate/db';
+import {UserRole} from '@next-nest-turbo-auth-boilerplate/shared';
+import {UsersController} from './users.controller';
+import {UsersService} from './users.service';
+
+const user: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  passwordHash: 'stored-password-hash',
+  role: UserRole.USER,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const userDto = {
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt,
+};
+
+describe('UsersController', () => {
+  const usersService = {
+    findById: jest.fn(async () => user),
+    toDto: jest.fn(() => userDto),
+  } as unknown as UsersService;
+
+  const controller = new UsersController(usersService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads the current user dto from the payload subject', async () => {
+    await expect(
+      controller.getMe({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+      }),
+    ).resolves.toEqual(userDto);
+
+    expect(usersService.findById).toHaveBeenCalledWith(user.id);
+    expect(usersService.toDto).toHaveBeenCalledWith(user);
+  });
+});

--- a/apps/nestjs-backend/test/auth.e2e-spec.ts
+++ b/apps/nestjs-backend/test/auth.e2e-spec.ts
@@ -1,0 +1,159 @@
+import {type ExecutionContext, type INestApplication, UnauthorizedException} from '@nestjs/common';
+import {Test, type TestingModule} from '@nestjs/testing';
+import {type User} from '@next-nest-turbo-auth-boilerplate/db';
+import {UserRole} from '@next-nest-turbo-auth-boilerplate/shared';
+import {type Request} from 'express';
+import {AuthController} from '../src/auth/auth.controller';
+import {AuthService} from '../src/auth/auth.service';
+import {JwtAuthGuard} from '../src/auth/guards/jwt-auth.guard';
+import {type JwtPayload} from '../src/auth/strategies/jwt.strategy';
+import {UsersController} from '../src/users/users.controller';
+import {UsersService} from '../src/users/users.service';
+
+const user: User = {
+  id: 'user-1',
+  email: 'user@example.com',
+  passwordHash: 'stored-password-hash',
+  role: UserRole.USER,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const userDto = {
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  createdAt: user.createdAt.toISOString(),
+  updatedAt: user.updatedAt.toISOString(),
+};
+
+const authPayload: JwtPayload = {
+  sub: user.id,
+  email: user.email,
+  role: user.role,
+};
+
+describe('Auth flows (e2e)', () => {
+  let app: INestApplication;
+  let jwtGuardSpy: jest.SpiedFunction<JwtAuthGuard['canActivate']>;
+
+  beforeAll(async () => {
+    jwtGuardSpy = jest.spyOn(JwtAuthGuard.prototype, 'canActivate').mockImplementation((context: ExecutionContext) => {
+      const request = context.switchToHttp().getRequest<Request & {user?: JwtPayload}>();
+
+      if (request.headers.authorization === 'Bearer valid-token') {
+        request.user = authPayload;
+        return true;
+      }
+
+      throw new UnauthorizedException();
+    });
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController, UsersController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            async register(): Promise<{user: typeof userDto; accessToken: string}> {
+              return {user: userDto, accessToken: 'registered-token'};
+            },
+            async login(dto: {email: string}): Promise<{user: typeof userDto; accessToken: string}> {
+              if (dto.email === 'invalid@example.com') {
+                throw new UnauthorizedException('Invalid credentials');
+              }
+
+              return {user: userDto, accessToken: 'valid-token'};
+            },
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            async findById(): Promise<User> {
+              return user;
+            },
+            toDto(): typeof userDto {
+              return userDto;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    await app.listen(0, '127.0.0.1');
+  });
+
+  afterAll(async () => {
+    await app.close();
+    jwtGuardSpy.mockRestore();
+  });
+
+  it('registers through the HTTP endpoint and sets the access token cookie', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/auth/register`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({email: user.email, password: 'password123'}),
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      user: userDto,
+      accessToken: 'registered-token',
+    });
+    expect(response.headers.get('set-cookie')).toContain('access_token=registered-token');
+  });
+
+  it('logs in through the HTTP endpoint and sets the access token cookie', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({email: user.email, password: 'password123'}),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      user: userDto,
+      accessToken: 'valid-token',
+    });
+    expect(response.headers.get('set-cookie')).toContain('access_token=valid-token');
+  });
+
+  it('returns unauthorized for invalid login credentials', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({email: 'invalid@example.com', password: 'password123'}),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('clears the access token cookie on logout', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/auth/logout`, {
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('set-cookie')).toContain('access_token=;');
+  });
+
+  it('returns the current authenticated user over HTTP when the auth header is valid', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/users/me`, {
+      headers: {
+        authorization: 'Bearer valid-token',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(userDto);
+  });
+
+  it('returns unauthorized for users/me without a valid auth header', async () => {
+    const response = await fetch(`${await app.getUrl()}/api/v1/users/me`);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/vite-frontend/tests/login.spec.ts
+++ b/apps/vite-frontend/tests/login.spec.ts
@@ -1,10 +1,115 @@
-import {expect, test} from '@playwright/test';
+import {type Page, expect, test} from '@playwright/test';
+
+const user = {
+  id: 'user-1',
+  email: 'user@example.com',
+  role: 'USER',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+async function mockAuthApi(page: Page): Promise<void> {
+  let isAuthenticated = false;
+
+  await page.route('**/api/v1/**', async (route) => {
+    const request = route.request();
+    const url = request.url();
+
+    if (request.method() === 'GET' && url.endsWith('/users/me')) {
+      await route.fulfill({
+        status: isAuthenticated ? 200 : 401,
+        contentType: 'application/json',
+        body: JSON.stringify(isAuthenticated ? user : {message: 'Unauthorized', statusCode: 401}),
+      });
+      return;
+    }
+
+    if (request.method() === 'POST' && url.endsWith('/auth/login')) {
+      const body = request.postDataJSON() as {email?: string; password?: string};
+
+      if (body.email === user.email && body.password === 'password123') {
+        isAuthenticated = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({user, accessToken: 'valid-token'}),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({message: 'Invalid credentials', statusCode: 401}),
+      });
+      return;
+    }
+
+    if (request.method() === 'POST' && url.endsWith('/auth/register')) {
+      isAuthenticated = true;
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({user, accessToken: 'registered-token'}),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({message: `Unhandled API request: ${request.method()} ${url}`}),
+    });
+  });
+}
+
+test.beforeEach(async ({page}) => {
+  await mockAuthApi(page);
+});
 
 test('renders the locale-aware login page', async ({page}) => {
   await page.goto('/en/login');
 
   await expect(page.getByRole('heading', {name: 'Sign In'})).toBeVisible();
   await expect(page.getByLabel('Email')).toBeVisible();
-  await expect(page.getByLabel('Password')).toBeVisible();
+  await expect(page.getByLabel('Password', {exact: true})).toBeVisible();
   await expect(page.getByRole('button', {name: 'Sign In'})).toBeVisible();
+});
+
+test('renders the locale-aware register page', async ({page}) => {
+  await page.goto('/en/register');
+
+  await expect(page.getByRole('heading', {name: 'Sign Up'})).toBeVisible();
+  await expect(page.getByLabel('Email')).toBeVisible();
+  await expect(page.getByLabel('Password', {exact: true})).toBeVisible();
+  await expect(page.getByLabel('Confirm Password')).toBeVisible();
+  await expect(page.getByRole('button', {name: 'Sign Up'})).toBeVisible();
+});
+
+test('redirects unauthenticated users from the protected locale root to login', async ({page}) => {
+  await page.goto('/en');
+
+  await expect(page).toHaveURL(/\/en\/login$/u);
+  await expect(page.getByRole('heading', {name: 'Sign In'})).toBeVisible();
+});
+
+test('signs in successfully and lands on the locale home route', async ({page}) => {
+  await page.goto('/en/login');
+
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password', {exact: true}).fill('password123');
+  await page.getByRole('button', {name: 'Sign In'}).click();
+
+  await expect(page).toHaveURL(/\/en$/u);
+  await expect(page.getByRole('heading', {name: 'Welcome to Vite - NestJS - Turbo Boilerplate'})).toBeVisible();
+});
+
+test('shows a toast when login fails with unauthorized credentials', async ({page}) => {
+  await page.goto('/en/login');
+
+  await page.getByLabel('Email').fill('invalid@example.com');
+  await page.getByLabel('Password', {exact: true}).fill('password123');
+  await page.getByRole('button', {name: 'Sign In'}).click();
+
+  await expect(page.getByText('Invalid email or password.')).toBeVisible();
 });


### PR DESCRIPTION
Closes #31

## Summary
- add backend unit coverage for auth service, auth controller, and users controller flows
- add backend HTTP smoke coverage for register, login, logout, and users/me with mocked auth behavior
- expand Playwright coverage for register rendering, protected-route redirects, login success, and login failure
- mock `/api/v1/**` traffic in Playwright so frontend e2e stays hermetic

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:unit`
- `npm run test:e2e`

## Notes
- The root `test:unit` run still shows the existing Turbo outputs warning because issue #27 has not been merged into `main` yet; the test suite itself passes.
