### PR TITLE
chore: add Cursor skill for CN mirror switching on request

### DIFF
--- a/.cursor/skills/switch-to-cn-mirror-on-request/SKILL.md
+++ b/.cursor/skills/switch-to-cn-mirror-on-request/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: switch-to-cn-mirror-on-request
+description: Use when the user explicitly asks to switch to a mainland China mirror source, mentions 国内镜像源 or 中国镜像源, or approves changing mirrors after Docker image layer downloads stall during deployment or container builds.
+---
+
+# Switch To CN Mirror On Request
+
+## Overview
+
+Only switch to mainland China mirror sources when the user explicitly asks for it, or when a verified image-pull bottleneck exists and the user approves the change.
+
+Do not switch mirrors preemptively.
+
+## Trigger Rules
+
+Use this skill when any of these are true:
+
+- The user explicitly says `国内镜像源`, `中国镜像源`, `mirror`, `加速`, or asks to switch sources in mainland China.
+- A Docker build is stuck on a layer download and the user approves switching mirrors.
+- The task is deployment-oriented and the user has already required slower downloads to be handled by swapping mirrors.
+
+Do not use this skill for generic build failures, application runtime bugs, or `npm ci` errors that are unrelated to network pulls.
+
+## Quick Triage
+
+Before changing anything, verify whether the slowdown is actually in image pulling:
+
+- Check exact base image cache state with `docker image inspect <image>`.
+- Re-run one service build with `docker compose build --progress=plain <service>`.
+- If the stall is on a line like `sha256:... 2.26MB / 51.06MB 755.0s`, treat it as a registry-layer download problem, not an app-build problem.
+- If the delay is inside `npm ci`, switch the package registry inside the Dockerfile instead of the base image source only.
+
+## Approved Mirror Addresses
+
+Use these exact mirrored image prefixes when Docker Hub pulls are the bottleneck:
+
+- `m.daocloud.io/docker.io/library/node:24.13.1-alpine`
+- `m.daocloud.io/docker.io/nginxinc/nginx-unprivileged:1.27-alpine`
+
+Use this package registry inside Dockerfiles when `npm` downloads are the bottleneck:
+
+- `https://registry.npmmirror.com`
+
+## Procedure
+
+1. Confirm the slowdown is in Docker layer pulling, not in `npm ci` or `turbo build`.
+2. Replace only the deployment Dockerfile base images with the mirrored image addresses.
+3. Keep the `npm` registry override in the Dockerfile when workspace dependency downloads are part of the build.
+4. Pre-pull the mirrored base images once with `docker pull` to validate the mirror path before a full rollout.
+5. Re-run a single service build with `--progress=plain` and compare timing.
+6. Only after the single build succeeds, continue with the full compose build or deployment.
+
+## Common Mistakes
+
+- Switching mirrors without explicit user approval or request.
+- Changing only the `npm` registry when the actual stall is a Docker base layer pull.
+- Updating the top-level deployment Dockerfile but forgetting to copy it into the active release directory before rebuilding.
+- Treating post-mirror build failures as mirror problems when they are actually code or config issues.
+
+## Detailed Reference
+
+For a generic incident pattern, example stalled layer output, mirror addresses, and verification workflow, read [references/docker-mirror-triage.md](references/docker-mirror-triage.md).

--- a/.cursor/skills/switch-to-cn-mirror-on-request/references/docker-mirror-triage.md
+++ b/.cursor/skills/switch-to-cn-mirror-on-request/references/docker-mirror-triage.md
@@ -1,0 +1,87 @@
+# Docker Mirror Triage
+
+## Purpose
+
+Use this reference when a deployment or container build is slow and the user has explicitly asked to switch to a mainland China mirror source.
+
+This document is intentionally generic. It describes how to distinguish Docker image pull slowness from application build slowness, and how to validate a mirror swap safely.
+
+## Verified Symptom Pattern
+
+The key symptom is a Docker image layer download that barely progresses for a long time.
+
+Example:
+
+```text
+#6 sha256:8ba8341791ce72c3cdec81ab7f3abf29803e34a45ed9a8389accf9dbc4fa8355 2.26MB / 51.06MB 755.0s
+```
+
+Interpretation:
+
+- This indicates a registry-layer pull stall.
+- It does not, by itself, indicate a problem in `npm ci`.
+- It does not, by itself, indicate a problem in `turbo build`, `vite build`, `nest build`, or the application runtime.
+
+## Generic Root Cause Checklist
+
+Before changing any source:
+
+1. Check whether the exact base images are already cached with `docker image inspect <image>`.
+2. Re-run one affected service build with `docker compose build --progress=plain <service>`.
+3. If the delay happens before application source is compiled, treat it as a registry pull problem.
+4. If the delay is inside package-manager output, treat it as a package registry problem instead.
+
+## Approved Mirror Examples
+
+These are examples of mirrored Docker base image paths that were validated in practice:
+
+```text
+m.daocloud.io/docker.io/library/node:24.13.1-alpine
+m.daocloud.io/docker.io/nginxinc/nginx-unprivileged:1.27-alpine
+```
+
+This is an example `npm` registry that was validated in practice:
+
+```text
+https://registry.npmmirror.com
+```
+
+These examples are useful defaults, but they should still be validated in the user’s environment.
+
+## Validation Workflow
+
+1. Confirm the user explicitly wants a mainland China mirror source.
+2. Change only the deployment Dockerfile base images first.
+3. If package downloads are also slow, change the package registry inside the Dockerfile.
+4. Pre-pull the mirrored base images with `docker pull` before running a full deployment build.
+5. Re-run a single service build with `--progress=plain`.
+6. Compare the timing before and after the mirror change.
+
+## Example Commands
+
+```bash
+docker pull m.daocloud.io/docker.io/library/node:24.13.1-alpine
+docker pull m.daocloud.io/docker.io/nginxinc/nginx-unprivileged:1.27-alpine
+```
+
+Example Dockerfile pattern:
+
+```dockerfile
+FROM m.daocloud.io/docker.io/library/node:24.13.1-alpine AS builder
+FROM m.daocloud.io/docker.io/library/node:24.13.1-alpine AS runner
+FROM m.daocloud.io/docker.io/nginxinc/nginx-unprivileged:1.27-alpine AS runner
+
+RUN npm config set registry https://registry.npmmirror.com \
+  && npm install -g turbo
+```
+
+## Common Follow-On Issues
+
+Once the mirror bottleneck is removed, a second class of failures often becomes visible:
+
+1. Missing files in the Docker build context.
+2. Environment-variable validation failures.
+3. Old deployment files still being used in the active release directory.
+4. Runtime health-check failures that were previously masked by the stalled build.
+
+These are not mirror-source problems. Treat them as separate deployment or application issues.


### PR DESCRIPTION
Guides agents to switch Docker/npm mirrors only when the user explicitly asks or approves, with triage steps and validated mirror addresses.